### PR TITLE
Adding Kover to Xbootclasspath.

### DIFF
--- a/kotlin/internal/jvm/kover.bzl
+++ b/kotlin/internal/jvm/kover.bzl
@@ -78,8 +78,11 @@ def get_kover_jvm_flags(kover_agent_files, kover_args_file):
     returns:
         the flag string to be used by test runner jvm
     """
-
-    return "-javaagent:%s=file:%s" % (kover_agent_files[0].short_path, kover_args_file.short_path)
+    jvm_args = [
+        "-Xbootclasspath/a:%s" % (kover_agent_files[0].short_path),
+        "-javaagent:%s=file:%s" % (kover_agent_files[0].short_path, kover_args_file.short_path)
+    ]
+    return " ".join(jvm_args)
 
 def create_kover_agent_actions(ctx, name):
     """ Generate the actions needed to emit Kover code coverage metadata file. It creates


### PR DESCRIPTION
If a function runs that uses the bootstrap classloader's search path, you will hit a ClassNotFoundException as the runtime tries to find Kover agents' classes.

### Reproduction:
./bazelw test -s //libraries/foundation/hyperion/ksp:test_main --collect_code_coverage --combined_report=lcov

On a target that invokes 
javax.lang.model.SourceVersion.latestSupported().compareTo(SourceVersion.RELEASE_8) > 0

such as invoking com.tschuchort.compiletesting.KotlinCompilation()


